### PR TITLE
Upgrade requests for lets encrypt certificate update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ## [Unreleased]
 
+## [dogwood.3-2021.10.01] - 2021-10-01
+
 ### Fixed
 
 - Upgrade requests to v2.26.0 to recognize Let's Encrypt certificate
@@ -22,5 +24,6 @@ release.
   [openfun/openedx-ecommerce-docker](https://github.com/openfun/openedx-ecommerce-docker)
   project.
 
-[unreleased]: https://github.com/openfun/ecommerce/compare/dogwood.3...fun/ecommerce-ol
+[unreleased]: https://github.com/openfun/ecommerce/compare/dogwood.3-2021.10.01...fun/ecommerce-ol
+[dogwood.3-2021.10.01]: https://github.com/openfun/ecommerce/compare/dogwood.3...dogwood.3-2021.10.01
 [dogwood.3]: https://github.com/openfun/ecommerce/releases/tag/dogwood.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Upgrade requests to v2.26.0 to recognize Let's Encrypt certificate
+
 ## [dogwood.3] - 2020-01-03
 
 ### Added

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,5 +25,5 @@ python-dateutil==2.4.2
 # Force python-social-auth release to fix edx-auth-backends buggy requirements
 python-social-auth==0.2.21
 pytz==2015.7
-requests==2.8.1
+requests==2.26.0
 suds==0.4


### PR DESCRIPTION
🔖(fix) bump release to dogwood.3-2021.10.01

### Fixed

- Upgrade requests to v2.26.0 to recognize Let's Encrypt certificate
